### PR TITLE
Fix license in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ AudienceHero has been created by [Marc Weistroff](https://marc.weistroff.net).
 
 ## Licensing
 
-AudienceHero is an Open Source software, released under the Affero General Public License. 
+AudienceHero is an Open Source software, released under the MIT License. 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ What is AudienceHero?
 =====================
 
 AudienceHero is a modular API-Centric Audience Management System.
-AudienceHero is a free (as in speech, and as in beer) software licensed under the Affero General Public License.
+AudienceHero is a free (as in speech, and as in beer) software licensed under the MIT License.
 
 Wait! What?
 -----------


### PR DESCRIPTION
Changing license for MIT in README and doc website to be consistent with commit https://github.com/AudienceHero/AudienceHero/commit/84daf6bf226627270c0360e72a2c4fd4fa0f2ca2